### PR TITLE
Prevent unecessary API calls

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -24,14 +24,23 @@ export default class App extends Component {
       <main className="App">
         <h1>Rancid Tomatillos</h1>
         <Switch>
-          <Route exact path="/" render={() => 
-            <MovieContainer 
+          <Route exact path="/" render={() =>
+            <MovieContainer
               movies={this.state.searchResults || this.state.movies}
               filterMovies={this.filterMovies}
-              isLoaded={this.state.isLoaded} 
-            /> } 
+              isLoaded={this.state.isLoaded}
+            /> }
           />
-          <Route path="/:id" render={(props) => <MovieDetailsCard movieID={props.match.params.id} /> } />
+          <Route
+            exact
+            path="/:id"
+            render={({ match }) => {
+              const idMatch = parseInt(match.params.id);
+              const foundMovie = this.state.movies.find(movie => movie.id === idMatch);
+              return <MovieDetailsCard movie={foundMovie}/>
+              }
+            }
+          />
         </Switch>
       </main>
     )

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -39,7 +39,7 @@ export default class App extends Component {
             render={({ match }) => {
               const idMatch = parseInt(match.params.id);
               const foundMovie = this.state.movies.find(movie => movie.id === idMatch);
-              return <MovieDetailsCard movie={foundMovie}/>
+              return <MovieDetailsCard movieID={idMatch} movie={foundMovie}/>
               }
             }
           />

--- a/src/details/MovieDetailsCard.js
+++ b/src/details/MovieDetailsCard.js
@@ -1,15 +1,14 @@
 import React, { Component } from 'react';
-import { fetchMovieDetails } from '../APICalls'
 import { Link } from 'react-router-dom';
 import './MovieDetailsCard.css'
 import VideoSection from '../VideoSection/VideoSection'
 
 class MovieDetailsCard extends Component {
-  constructor({ movieID }) {
+  constructor({ movie }) {
     super()
     this.state = {
-      id: movieID,
-      movie: null,
+      id: movie.id,
+      movie: movie || null,
       error: null
     }
   }
@@ -53,12 +52,6 @@ class MovieDetailsCard extends Component {
         </div>
       )
     }
-  }
-
-  componentDidMount() {
-    fetchMovieDetails(this.state.id)
-    .then(movieDetails => this.setState({movie: movieDetails}))
-    .catch(err => this.setState({error: this.handleErrorResponse(err.message)}))
   }
 
   handleErrorResponse(error) {

--- a/src/details/MovieDetailsCard.js
+++ b/src/details/MovieDetailsCard.js
@@ -1,13 +1,14 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import './MovieDetailsCard.css'
-import VideoSection from '../VideoSection/VideoSection'
+import './MovieDetailsCard.css';
+import VideoSection from '../VideoSection/VideoSection';
+import { fetchMovieDetails } from '../APICalls';
 
 class MovieDetailsCard extends Component {
-  constructor({ movie }) {
+  constructor({ movieID, movie }) {
     super()
     this.state = {
-      id: movie.id,
+      id: movieID,
       movie: movie || null,
       error: null
     }
@@ -15,7 +16,9 @@ class MovieDetailsCard extends Component {
 
 
   render() {
-    document.querySelector('.search-bar').classList.add('hidden')
+    if (document.querySelector('.search-bar')) {
+      document.querySelector('.search-bar').classList.add('hidden')
+    }
     if(this.state.movie && !this.state.error) {
       return (
         <div className='movie-details-card' style={{backgroundImage: `url(${this.state.movie.backdrop_path})`}}>
@@ -53,6 +56,16 @@ class MovieDetailsCard extends Component {
           <Link to={`/`}><button className='back-button'>BACK</button></Link>
         </div>
       )
+    }
+  }
+
+  componentDidMount() {
+    if (!this.state.movie) {
+      fetchMovieDetails(this.state.id)
+      .then(movieDetails => {
+        this.setState({ movie: movieDetails })
+      })
+      .catch(err => this.setState({error: this.handleErrorResponse(err.message)}))
     }
   }
 

--- a/src/details/MovieDetailsCard.js
+++ b/src/details/MovieDetailsCard.js
@@ -13,6 +13,7 @@ class MovieDetailsCard extends Component {
     }
   }
 
+
   render() {
     document.querySelector('.search-bar').classList.add('hidden')
     if(this.state.movie && !this.state.error) {


### PR DESCRIPTION
 ** The easiest way to merge this branch is by merging the previous PR first, giving me a heads up on that so I can resolve conflicts on my local machine, then I can push up to this branch again so that it will be ready to merge into main here on GitHub.

## What does this PR do?
 -  Removes the additional API calls triggered on movie poster click that were necessary for previous iterations, but are redundant now that we make all the needed calls up front on page load
 
## How should it be tested?
 - All functionality should be the same, but no more API calls should be initiated when clicking on an individual movie posters
